### PR TITLE
more concise and extended benchmark

### DIFF
--- a/rbf_benchmark/CMakeLists.txt
+++ b/rbf_benchmark/CMakeLists.txt
@@ -2,12 +2,18 @@ cmake_minimum_required(VERSION 2.8.3)
 project(rbf_benchmark)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
-# add_compile_options(-std=c++11)
+add_compile_options(-std=c++11)
+
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "Release" CACHE STRING
+      "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel."
+      FORCE)
+endif(NOT CMAKE_BUILD_TYPE)
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED geometry_msgs ros_babel_fish)
+find_package(catkin REQUIRED geometry_msgs ros_babel_fish ros_type_introspection nav_msgs tf)
 
 ## System dependencies are found with CMake's conventions
 find_package(benchmark REQUIRED)
@@ -17,38 +23,16 @@ set(LIBRARIES
   benchmark
 )
 
-# Optionally benchmark against ros_type_introspeciton
-find_package(ros_type_introspection)
-
-if (ros_type_introspection_FOUND)
-  find_package(topic_tools REQUIRED)
-  set(LIBRARIES
-    ${LIBRARIES}
-    ${ros_type_introspection_LIBRARIES}
-    ${topic_tools_LIBRARIES}
-  )
-  add_definitions(-DENABLE_RTI)
-endif()
-
 ## Uncomment this if the package has a setup.py. This macro ensures
 ## modules and global scripts declared therein get installed
 ## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
 # catkin_python_setup()
 
-###################################
-## catkin specific configuration ##
-###################################
-## The catkin_package macro generates cmake config files for your package
-## Declare things to be passed to dependent projects
-## INCLUDE_DIRS: uncomment this if your package contains header files
-## LIBRARIES: libraries you create in this project that dependent projects also need
-## CATKIN_DEPENDS: catkin_packages dependent projects also need
-## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES rbf_benchmark
-  CATKIN_DEPENDS geometry_msgs ros_babel_fish
-#  DEPENDS system_lib
+  CATKIN_DEPENDS geometry_msgs ros_babel_fish ros_type_introspection nav_msgs tf
+  DEPENDS benchmark
 )
 
 ###########
@@ -64,24 +48,14 @@ include_directories(
 )
 
 add_executable(message_lookup src/message_lookup.cpp)
-target_link_libraries(message_lookup ${LIBRARIES})
+target_link_libraries(message_lookup ${LIBRARIES} pthread)
 
 add_executable(message_translation src/message_translation.cpp)
-target_link_libraries(message_translation ${LIBRARIES})
+target_link_libraries(message_translation ${LIBRARIES} pthread)
 
 #############
 ## Install ##
 #############
-
-# all install targets should use catkin DESTINATION variables
-# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
-
-## Mark executable scripts (Python etc.) for installation
-## in contrast to setup.py, you can choose the destination
-# install(PROGRAMS
-#   scripts/my_python_script
-#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
 
 ## Mark executables for installation
 ## See http://docs.ros.org/melodic/api/catkin/html/howto/format1/building_executables.html
@@ -89,9 +63,4 @@ install(TARGETS message_lookup message_translation
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
-## Mark other files for installation (e.g. launch and bag files, etc.)
-# install(FILES
-#   # myfile1
-#   # myfile2
-#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-# )
+

--- a/rbf_benchmark/package.xml
+++ b/rbf_benchmark/package.xml
@@ -52,6 +52,9 @@
 
   <depend>geometry_msgs</depend>
   <depend>ros_babel_fish</depend>
+  <depend>ros_type_introspection</depend>
+  <depend>nav_msgs</depend>
+  <depend>tf</depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>


### PR DESCRIPTION
- Use Rosintrospection::ShapeShifter to use zero-copy buffer
- transform benchmarks into templates to greatly reduce copy-and-paste
- added JointState

these are the results on my machine:

```
-------------------------------------------------------------------------
Benchmark                               Time             CPU   Iterations
-------------------------------------------------------------------------
RTI_ParseMessageDefinitionPose       97.0 us         96.6 us         7093
RBF_ParseMessageDefinitionPose       5800 us         5789 us          123
RTI_ParseMessagePose                  398 ns          397 ns      1777443
RBF_ParseMessagePose                 2040 ns         2031 ns       345294
RTI_ParseMessagePointcloud           9766 ns         9721 ns        72176
RBF_ParseMessagePointcloud           3359 ns         3341 ns       210706
RTI_ParseMessageFullHDImage         65924 ns        65575 ns        10136
RBF_ParseMessageFullHDImage          1991 ns         1981 ns       353167
RTI_ParseMessageJointState            639 ns          637 ns      1088449
RBF_ParseMessageJointState           1874 ns         1865 ns       372415
```
As you can see, the RTI for Pointcloud and FullHDImage is still worse but twice as fast as better.
